### PR TITLE
Add support for GreaterOrEqual, LessOrEqual, Approx and Extensible filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This is a thin wrapper over the async client for minimal usage and testing.
 | bind | rfc4511  | ✅ (only simple bind will be supported) |
 | unbind | rfc4511 | ✅ |
 | search | rfc4511 | ✅ |
-| filter | rfc4511 | 🔨 (excluding ge, le, aprx, ext) |
+| filter | rfc4511 | ✅ |
 | modify | rfc4511 | ✅ |
 | add | rfc4511 | ✅ |
 | delete | rfc4511 | ✅ |

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -171,7 +171,12 @@ mod tests {
                             any: vec![],
                             final_: None
                         }
-                    )
+                    ),
+                    LdapFilter::GreaterOrEqual("createTimestamp".to_string(), "20070101000000Z".to_string()),
+                    LdapFilter::LessOrEqual("createTimestamp".to_string(), "21000101000000Z".to_string()),
+                    LdapFilter::Approx("cn".to_string(), "abc".to_string()),
+                    LdapFilter::Extensible(LdapMatchingRuleAssertion { matching_rule: Some("1.2.840.113556.1.4.1941".to_string()),
+                     type_: Some("memberOf".to_string()), match_value: "cn=test,ou=groups,dc=example,dc=com".to_string(), dn_attributes: true }),
                 ]),
                 attrs: vec!["cn".to_string(), "objectClass".to_string(),],
             }),


### PR DESCRIPTION
It would be nice if the unimplemented parts of the filter could be supported.