### PR TITLE
Add simple compare and openssl-vendored

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 [features]
 default = ["strict"]
 strict = ["ldap3_proto/strict"]
+openssl-vendored = ["openssl/vendored"]
 
 [lib]
 name = "ldap3_client"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 [features]
 default = ["strict"]
 strict = []
+openssl-vendored = ["openssl/vendored"]
 
 [dependencies]
 bytes.workspace = true

--- a/proto/examples/tokio/main.rs
+++ b/proto/examples/tokio/main.rs
@@ -62,6 +62,10 @@ impl LdapSession {
         ]
     }
 
+    pub fn do_compare(&mut self, cp: &CompareRequest) -> LdapMsg {
+        cp.gen_success()
+    }
+
     pub fn do_whoami(&mut self, wr: &WhoamiRequest) -> LdapMsg {
         wr.gen_success(format!("dn: {}", self.dn).as_str())
     }
@@ -103,6 +107,7 @@ async fn handle_client(socket: TcpStream, _paddr: net::SocketAddr) {
                 // No need to notify on unbind (per rfc4511)
                 return;
             }
+            ServerOps::Compare(cp) => vec![session.do_compare(&cp)],
             ServerOps::Whoami(wr) => vec![session.do_whoami(&wr)],
         };
 

--- a/proto/examples/tokio/main.rs
+++ b/proto/examples/tokio/main.rs
@@ -63,7 +63,7 @@ impl LdapSession {
     }
 
     pub fn do_compare(&mut self, cp: &CompareRequest) -> LdapMsg {
-        cp.gen_success()
+        cp.gen_compare_true()
     }
 
     pub fn do_whoami(&mut self, wr: &WhoamiRequest) -> LdapMsg {

--- a/proto/src/simple.rs
+++ b/proto/src/simple.rs
@@ -242,7 +242,7 @@ impl SimpleBindRequest {
 }
 
 impl CompareRequest {
-    pub fn gen_success(&self) -> LdapMsg {
+    pub fn gen_compare_true(&self) -> LdapMsg {
         LdapMsg {
             msgid: self.msgid,
             op: LdapOp::CompareResult(LdapResult {
@@ -255,7 +255,7 @@ impl CompareRequest {
         }
     }
 
-    pub fn gen_failed(&self) -> LdapMsg {
+    pub fn gen_compare_false(&self) -> LdapMsg {
         LdapMsg {
             msgid: self.msgid,
             op: LdapOp::CompareResult(LdapResult {


### PR DESCRIPTION
Add some simple implementations and functions to facilitate user use and personalized compilation.
- add simple compare 
- add `openssl-vendored` features