### PR TITLE
20230905 improve errors ber sizing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ debug = true
 lto = "thin"
 
 [workspace]
+resolver = "2"
 members = [
     "proto",
     "client",
@@ -42,6 +43,7 @@ rpassword = "7.0.0"
 serde = { version = "^1.0.136", features = ["derive"] }
 serde_json = "^1.0.79"
 serde_test = "^1.0.56"
+thiserror = "1.0"
 tokio = "^1.17.0"
 tokio-util = "^0.7.1"
 tokio-openssl = "^0.6.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ repository = "https://github.com/kanidm/ldap3/"
 keywords = ["ldap", "protocol", "authentication", "chaos"]
 
 [workspace.dependencies]
-base64 = "0.13"
-base64urlsafedata = "0.1.0"
+base64 = "0.21"
+base64urlsafedata = "0.1.3"
 bytes = "^1.1.0"
 clap = "^3.2"
 clap_complete = "^3.2.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 
 [workspace.package]
-version = "0.3.5"
+version = "0.4.0"
 authors = [
     "William Brown <william@blackhats.net.au>",
     ]
@@ -34,8 +34,8 @@ futures-util = "^0.3.21"
 lber = "^0.4.0"
 # Must match lber
 nom = "7"
-ldap3_client = { path = "./client", version = "0.3.5" }
-ldap3_proto = { path = "./proto", version = "0.3.5" }
+ldap3_client = { path = "./client", version = "0.4.0" }
+ldap3_proto = { path = "./proto", version = "0.4.0" }
 peg = "0.8.1"
 openssl = "^0.10.38"
 ron = "^0.8.0"

--- a/cli/src/ldap.rs
+++ b/cli/src/ldap.rs
@@ -55,7 +55,7 @@ async fn main() {
         }
         std::process::exit(e as i32);
     } else {
-        ("".to_string(), "".to_string())
+        (String::new(), String::new())
     };
 
     let builder = LdapClientBuilder::new(&opt.url);

--- a/cli/src/ldap.rs
+++ b/cli/src/ldap.rs
@@ -15,6 +15,8 @@ use clap::Parser;
 use ldap3_client::proto::LdapFilter;
 use ldap3_client::*;
 
+use base64::{engine::general_purpose, Engine as _};
+
 include!("./ldap_opt.rs");
 
 #[tokio::main(flavor = "current_thread")]
@@ -190,7 +192,7 @@ async fn main() {
             let mode = proto::SyncRequestMode::RefreshOnly;
 
             let cookie = if let Some(cookie) = cookie {
-                match base64::decode_config(&cookie, base64::STANDARD_NO_PAD) {
+                match general_purpose::URL_SAFE.decode(&cookie) {
                     Ok(c) => Some(c),
                     Err(e) => {
                         error!(?e, "Failed to parse cookie");
@@ -250,7 +252,7 @@ async fn main() {
                     println!(
                         "cookie: {}",
                         cookie
-                            .map(|bin| base64::encode_config(bin, base64::STANDARD_NO_PAD))
+                            .map(|bin| general_purpose::URL_SAFE.encode(bin))
                             .unwrap_or_else(|| "NONE".to_string())
                     );
                 }
@@ -270,7 +272,7 @@ async fn main() {
         }
         LdapAction::AdDirsync { basedn, cookie } => {
             let cookie = if let Some(cookie) = cookie {
-                match base64::decode_config(&cookie, base64::STANDARD_NO_PAD) {
+                match general_purpose::URL_SAFE.decode(&cookie) {
                     Ok(c) => Some(c),
                     Err(e) => {
                         error!(?e, "Failed to parse cookie");
@@ -309,7 +311,7 @@ async fn main() {
                         "cookie: {}",
                         sync_repl
                             .cookie
-                            .map(|bin| base64::encode_config(bin, base64::STANDARD_NO_PAD))
+                            .map(|bin| general_purpose::URL_SAFE.encode(bin))
                             .unwrap_or_else(|| "NONE".to_string())
                     );
                 }

--- a/cli/src/ldap.rs
+++ b/cli/src/ldap.rs
@@ -43,21 +43,19 @@ async fn main() {
             };
             (dn.clone(), pw)
         }
-    } else {
-        if opt.bind_passwd.is_some() {
-            let e = LdapError::AnonymousInvalidState;
-            if opt.json {
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&e).expect("CRITICAL: Serialisation Fault")
-                );
-            } else {
-                error!("Anonymous does not take a password - {}", e);
-            }
-            std::process::exit(e as i32);
+    } else if opt.bind_passwd.is_some() {
+        let e = LdapError::AnonymousInvalidState;
+        if opt.json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&e).expect("CRITICAL: Serialisation Fault")
+            );
         } else {
-            ("".to_string(), "".to_string())
+            error!("Anonymous does not take a password - {}", e);
         }
+        std::process::exit(e as i32);
+    } else {
+        ("".to_string(), "".to_string())
     };
 
     let builder = LdapClientBuilder::new(&opt.url);
@@ -115,7 +113,7 @@ async fn main() {
                                     println!("{}: {}", attr, val);
                                 }
                             }
-                            println!("");
+                            println!();
                         }
                     }
                 }
@@ -226,7 +224,7 @@ async fn main() {
                                 println!("{}: {}", attr, val);
                             }
                         }
-                        println!("");
+                        println!();
                     }
                     if let Some(d_uuids) = &delete_uuids {
                         for entry_uuid in d_uuids {
@@ -236,15 +234,15 @@ async fn main() {
 
                     if let Some(p_uuids) = &present_uuids {
                         if !p_uuids.is_empty() {
-                            println!("");
+                            println!();
                         }
                         for entry_uuid in p_uuids {
                             println!("present entryuuid: {}", entry_uuid);
-                            println!("");
+                            println!();
                         }
                     }
 
-                    println!("");
+                    println!();
                     println!("refresh_deletes: {}", refresh_deletes);
                     println!("delete_phase: {}", delete_uuids.is_some());
                     println!("present_phase: {}", present_uuids.is_some());
@@ -252,7 +250,7 @@ async fn main() {
                     println!(
                         "cookie: {}",
                         cookie
-                            .map(|bin| base64::encode_config(&bin, base64::STANDARD_NO_PAD))
+                            .map(|bin| base64::encode_config(bin, base64::STANDARD_NO_PAD))
                             .unwrap_or_else(|| "NONE".to_string())
                     );
                 }
@@ -294,24 +292,24 @@ async fn main() {
                                 println!("{}: {}", attr, val);
                             }
                         }
-                        println!("");
+                        println!();
                     }
                     for entry_uuid in &sync_repl.delete_uuids {
                         println!("delete entryuuid: {}", entry_uuid);
                     }
                     if !sync_repl.present_uuids.is_empty() {
-                        println!("");
+                        println!();
                     }
                     for entry_uuid in &sync_repl.present_uuids {
                         println!("delete entryuuid: {}", entry_uuid);
-                        println!("");
+                        println!();
                     }
-                    println!("");
+                    println!();
                     println!(
                         "cookie: {}",
                         sync_repl
                             .cookie
-                            .map(|bin| base64::encode_config(&bin, base64::STANDARD_NO_PAD))
+                            .map(|bin| base64::encode_config(bin, base64::STANDARD_NO_PAD))
                             .unwrap_or_else(|| "NONE".to_string())
                     );
                 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -11,20 +11,20 @@
 // We allow expect since it forces good error messages at the least.
 #![allow(clippy::expect_used)]
 
+use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
 
 pub fn start_tracing(verbose: bool) {
     let fmt_layer = tracing_subscriber::fmt::layer().with_target(false);
-    let filter_layer = EnvFilter::try_from_default_env()
-        .or_else(|_| {
-            if verbose {
-                EnvFilter::try_new("info")
-            } else {
-                EnvFilter::try_new("warn")
-            }
-        })
-        .unwrap();
+    let level = if verbose {
+        LevelFilter::INFO
+    } else {
+        LevelFilter::WARN
+    };
+    let filter_layer = EnvFilter::builder()
+        .with_default_directive(level.into())
+        .from_env_lossy();
 
     tracing_subscriber::registry()
         .with(filter_layer)

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -422,14 +422,14 @@ impl<'a> LdapClientBuilder<'a> {
             info!("tls configured");
             let (r, w) = tokio::io::split(tlsstream);
             (
-                LdapWriteTransport::Tls(FramedWrite::new(w, LdapCodec)),
-                LdapReadTransport::Tls(FramedRead::new(r, LdapCodec)),
+                LdapWriteTransport::Tls(FramedWrite::new(w, LdapCodec::default())),
+                LdapReadTransport::Tls(FramedRead::new(r, LdapCodec::default())),
             )
         } else {
             let (r, w) = tokio::io::split(tcpstream);
             (
-                LdapWriteTransport::Plain(FramedWrite::new(w, LdapCodec)),
-                LdapReadTransport::Plain(FramedRead::new(r, LdapCodec)),
+                LdapWriteTransport::Plain(FramedWrite::new(w, LdapCodec::default())),
+                LdapReadTransport::Plain(FramedRead::new(r, LdapCodec::default())),
             )
         };
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -37,6 +37,8 @@ use std::fmt;
 use url::Url;
 use uuid::Uuid;
 
+use base64::{engine::general_purpose, Engine as _};
+
 pub use ldap3_proto::filter;
 pub use ldap3_proto::proto;
 
@@ -243,9 +245,7 @@ impl From<LdapSearchResultEntry> for LdapEntry {
                                     s.to_string()
                                 }
                             })
-                            .unwrap_or_else(|_| {
-                                base64::encode_config(&bin, base64::STANDARD_NO_PAD)
-                            })
+                            .unwrap_or_else(|_| general_purpose::URL_SAFE.encode(&bin))
                     })
                     .collect();
                 (atype, va)

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -412,7 +412,7 @@ impl<'a> LdapClientBuilder<'a> {
                     LdapError::TlsError
                 })?;
 
-            let _ = SslStream::connect(Pin::new(&mut tlsstream))
+            SslStream::connect(Pin::new(&mut tlsstream))
                 .await
                 .map_err(|e| {
                     error!(?e, "openssl");

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -24,6 +24,7 @@ tokio-util = { workspace = true, features = ["codec"] }
 tracing.workspace = true
 uuid.workspace = true
 serde = { workspace = true, optional = true }
+thiserror.workspace = true
 
 [dev-dependencies]
 tracing-subscriber.workspace = true

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -16,6 +16,7 @@ strict = []
 openssl-vendored = ["openssl/vendored"]
 
 [dependencies]
+base64.workspace = true
 bytes.workspace = true
 lber.workspace = true
 nom.workspace = true

--- a/proto/examples/clitest/main.rs
+++ b/proto/examples/clitest/main.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), ()> {
             eprintln!("Failed to initialise TLS -> {:?}", e);
         })?;
 
-    let mut framed = Framed::new(tlsstream, LdapCodec);
+    let mut framed = Framed::new(tlsstream, LdapCodec::default());
     // let mut framed = Framed::new(tcpstream, LdapCodec);
 
     let dn = "uid=demo_user,ou=people,dc=example,dc=com".to_string();

--- a/proto/examples/tokio/main.rs
+++ b/proto/examples/tokio/main.rs
@@ -74,8 +74,8 @@ impl LdapSession {
 async fn handle_client(socket: TcpStream, _paddr: net::SocketAddr) {
     // Configure the codec etc.
     let (r, w) = tokio::io::split(socket);
-    let mut reqs = FramedRead::new(r, LdapCodec);
-    let mut resp = FramedWrite::new(w, LdapCodec);
+    let mut reqs = FramedRead::new(r, LdapCodec::default());
+    let mut resp = FramedWrite::new(w, LdapCodec::default());
 
     let mut session = LdapSession {
         dn: "Anonymous".to_string(),

--- a/proto/src/error.rs
+++ b/proto/src/error.rs
@@ -55,8 +55,8 @@ pub enum LdapProtoError {
     ControlAdDirsyncInteger,
     #[error("Invalid integer in paged search control")]
     ControlPagedInteger,
-    #[error("Invalid utf8 data in paged search control")]
-    ControlPagedUtf8,
+    #[error("Missing cookie data in paged search control")]
+    ControlPagedCookie,
 
     #[error("Invalid BER in bind credentials")]
     BindCredBer,

--- a/proto/src/error.rs
+++ b/proto/src/error.rs
@@ -1,0 +1,131 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum LdapProtoError {
+    #[error("The whoami response contains an invalid 'name' field")]
+    WhoamiResponseName,
+
+    #[error("")]
+    PasswordModifyRequestOid,
+    #[error("")]
+    PasswordModifyRequestEmpty,
+    #[error("")]
+    PasswordModifyRequestBer,
+    #[error("")]
+    PasswordModifyRequestValueId,
+
+    #[error("")]
+    PasswordModifyResponseName,
+    #[error("")]
+    PasswordModifyResponseEmpty,
+    #[error("")]
+    PasswordModifyResponseBer,
+
+    #[error("The memory dump contains invalid BER")]
+    OlMemDumpBer,
+
+    #[error("")]
+    LdapMsgBer,
+    #[error("")]
+    LdapMsgSeqLen,
+    #[error("")]
+    LdapMsgId,
+    #[error("")]
+    LdapMsgOp,
+
+    #[error("")]
+    LdapOpTag,
+    #[error("")]
+    LdapOpUnknown,
+
+    #[error("")]
+    ControlUnknown,
+
+    #[error("")]
+    ControlBer,
+    #[error("")]
+    ControlSeqLen,
+    #[error("")]
+    ControlSyncMode,
+    #[error("")]
+    ControlSyncState,
+    #[error("")]
+    ControlSyncUuid,
+    #[error("")]
+    ControlAdDirsyncInteger,
+    #[error("")]
+    ControlPagedInteger,
+    #[error("")]
+    ControlPagedUtf8,
+
+    #[error("")]
+    BindCredBer,
+    #[error("")]
+    BindCredId,
+
+    #[error("")]
+    BindRequestVersion,
+    #[error("")]
+    BindRequestBer,
+
+    #[error("")]
+    ResultBer,
+
+    #[error("")]
+    FilterTag,
+    #[error("")]
+    FilterBer,
+
+    #[error("")]
+    SearchBer,
+
+    #[error("")]
+    ModifyBer,
+
+    #[error("")]
+    PartialAttributeBer,
+
+    #[error("")]
+    SearchResultEntryBer,
+
+    #[error("")]
+    ExtendedRequestBer,
+
+    #[error("")]
+    IntermediateResponseTag,
+    #[error("")]
+    IntermediateResponseId,
+    #[error("")]
+    IntermediateResponseBer,
+    #[error("")]
+    IntermediateResponseSyncUuid,
+
+    #[error("")]
+    ModifyTypeValue,
+    #[error("")]
+    SearchScopeValue,
+
+    #[error("")]
+    DerefAliasesValue,
+
+    #[error("")]
+    ModifyRequestBer,
+
+    #[error("")]
+    AddRequestBer,
+
+    #[error("")]
+    ModifyDNRequestBer,
+
+    #[error("")]
+    CompareRequestBer,
+
+    #[error("")]
+    ResultCode,
+
+    #[error("")]
+    DelRequestBer,
+
+    #[error("")]
+    AbandonRequestBer,
+}

--- a/proto/src/error.rs
+++ b/proto/src/error.rs
@@ -5,127 +5,127 @@ pub enum LdapProtoError {
     #[error("The whoami response contains an invalid 'name' field")]
     WhoamiResponseName,
 
-    #[error("")]
+    #[error("Invalid oid in extended request")]
     PasswordModifyRequestOid,
-    #[error("")]
+    #[error("Password modify request value empty")]
     PasswordModifyRequestEmpty,
-    #[error("")]
+    #[error("Invalid BER in password modify request")]
     PasswordModifyRequestBer,
-    #[error("")]
+    #[error("Invalid value id tag in password modify request")]
     PasswordModifyRequestValueId,
 
-    #[error("")]
+    #[error("Missing password modify response name")]
     PasswordModifyResponseName,
-    #[error("")]
+    #[error("Password modify response value empty")]
     PasswordModifyResponseEmpty,
-    #[error("")]
+    #[error("Invalid BER in password modify response")]
     PasswordModifyResponseBer,
 
     #[error("The memory dump contains invalid BER")]
     OlMemDumpBer,
 
-    #[error("")]
+    #[error("The LDAP msg contains invalid BER")]
     LdapMsgBer,
-    #[error("")]
+    #[error("The LDAP msg has an invalid sequence length")]
     LdapMsgSeqLen,
-    #[error("")]
+    #[error("The LDAP msg has an invalid id")]
     LdapMsgId,
-    #[error("")]
+    #[error("The LDAP msg has no operation")]
     LdapMsgOp,
 
-    #[error("")]
+    #[error("Invalid operation tag")]
     LdapOpTag,
-    #[error("")]
+    #[error("Unknown operation type. This may be a bug in ldap3_proto.")]
     LdapOpUnknown,
 
-    #[error("")]
+    #[error("The request control is unknown. This may be a bug in ldap3_proto.")]
     ControlUnknown,
 
-    #[error("")]
+    #[error("Control contains invalid BER")]
     ControlBer,
-    #[error("")]
+    #[error("The control has an invalid sequence length")]
     ControlSeqLen,
-    #[error("")]
+    #[error("Invalid sync mode id requested in control")]
     ControlSyncMode,
-    #[error("")]
+    #[error("Invalid sync state id requested in control")]
     ControlSyncState,
-    #[error("")]
+    #[error("Invalid sync uuid in control")]
     ControlSyncUuid,
-    #[error("")]
+    #[error("Invalid integer in ad dirsync control")]
     ControlAdDirsyncInteger,
-    #[error("")]
+    #[error("Invalid integer in paged search control")]
     ControlPagedInteger,
-    #[error("")]
+    #[error("Invalid utf8 data in paged search control")]
     ControlPagedUtf8,
 
-    #[error("")]
+    #[error("Invalid BER in bind credentials")]
     BindCredBer,
-    #[error("")]
+    #[error("Invalid value id in bind credentials")]
     BindCredId,
 
-    #[error("")]
+    #[error("Bind request version is not equal to 3. This is a serious client bug.")]
     BindRequestVersion,
-    #[error("")]
+    #[error("Invalid BER in bind request.")]
     BindRequestBer,
 
-    #[error("")]
+    #[error("Invalid BER in result.")]
     ResultBer,
 
-    #[error("")]
+    #[error("Invalid Tag in filter")]
     FilterTag,
-    #[error("")]
+    #[error("Invalid BER in filter")]
     FilterBer,
 
-    #[error("")]
+    #[error("Invalid BER in search")]
     SearchBer,
 
-    #[error("")]
+    #[error("Invalid BER in modify")]
     ModifyBer,
 
-    #[error("")]
+    #[error("Invalid BER in partial attribute")]
     PartialAttributeBer,
 
-    #[error("")]
+    #[error("Invalid BER in search result entry")]
     SearchResultEntryBer,
 
-    #[error("")]
+    #[error("Invalid BER in extended request")]
     ExtendedRequestBer,
 
-    #[error("")]
+    #[error("Intermediate response tag is invalid")]
     IntermediateResponseTag,
-    #[error("")]
+    #[error("Invalid intermediat response id")]
     IntermediateResponseId,
-    #[error("")]
+    #[error("Invalid BER in intermediate response")]
     IntermediateResponseBer,
-    #[error("")]
+    #[error("Invalid Sync UUID in intermediate response")]
     IntermediateResponseSyncUuid,
 
-    #[error("")]
+    #[error("Invalid modify type value")]
     ModifyTypeValue,
-    #[error("")]
+    #[error("Invalid search scope value")]
     SearchScopeValue,
 
-    #[error("")]
+    #[error("Invalid deref aliases value")]
     DerefAliasesValue,
 
-    #[error("")]
+    #[error("Invalid BER in modify request")]
     ModifyRequestBer,
 
-    #[error("")]
+    #[error("Invalid BER in add request")]
     AddRequestBer,
 
-    #[error("")]
+    #[error("Invalid BER in modify dn request")]
     ModifyDNRequestBer,
 
-    #[error("")]
+    #[error("Invalid BER in compare request")]
     CompareRequestBer,
 
-    #[error("")]
+    #[error("Invalid or unknown result code")]
     ResultCode,
 
-    #[error("")]
+    #[error("Invalid BER in delete request")]
     DelRequestBer,
 
-    #[error("")]
+    #[error("Invalid BER in abandon request")]
     AbandonRequestBer,
 }

--- a/proto/src/filter.rs
+++ b/proto/src/filter.rs
@@ -78,10 +78,10 @@ peg::parser! {
     }
 }
 
-pub fn parse_ldap_filter_str(f: &str) -> Result<LdapFilter, ()> {
-    ldapfilter::parse(f).map_err(|e| {
-        debug!("{:?}", e);
-    })
+pub fn parse_ldap_filter_str(
+    f: &str,
+) -> Result<LdapFilter, peg::error::ParseError<peg::str::LineCol>> {
+    ldapfilter::parse(f)
 }
 
 #[cfg(test)]

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -34,7 +34,7 @@ use tracing::{error, trace};
 pub use crate::filter::parse_ldap_filter_str;
 pub use crate::simple::*;
 
-const KILOBYTES: usize = 1048576;
+const KILOBYTES: usize = 1024;
 const DEFAULT_MAX_BER_SIZE: usize = 8 * KILOBYTES;
 
 pub struct LdapCodec {
@@ -86,7 +86,6 @@ impl Decoder for LdapCodec {
             ));
         }
 
-        // helper for when we need to debug inputs.
         if size == buf.len() {
             buf.clear();
         } else {

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -540,7 +540,7 @@ mod tests {
             }),
             ctrl: vec![LdapControl::SimplePagedResults {
                 size: 100,
-                cookie: "opaque".to_string(),
+                cookie: b"opaque".to_vec(),
             }],
         });
     }

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -15,6 +15,7 @@
 #[macro_use]
 extern crate tracing;
 
+pub mod error;
 pub mod filter;
 pub mod proto;
 pub mod simple;
@@ -31,7 +32,6 @@ use tokio_util::codec::{Decoder, Encoder};
 use tracing::{error, trace};
 
 pub use crate::filter::parse_ldap_filter_str;
-use crate::proto::LdapMsg;
 pub use crate::simple::*;
 
 pub struct LdapCodec;

--- a/proto/src/proto.rs
+++ b/proto/src/proto.rs
@@ -740,11 +740,11 @@ impl TryFrom<StructureTag> for LdapMsg {
             .and_then(|t| t.match_id(0))
             // So it's probably controls, decode them?
             .and_then(|t| t.expect_constructed())
-            .unwrap_or_else(Vec::new);
+            .unwrap_or_default();
 
         let ctrl = ctrl_vec
             .into_iter()
-            .map(|t| TryInto::<LdapControl>::try_into(t))
+            .map(TryInto::<LdapControl>::try_into)
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(LdapMsg { msgid, op, ctrl })
@@ -2811,7 +2811,7 @@ impl TryFrom<Vec<StructureTag>> for LdapIntermediateResponse {
                     }
                     _ => {
                         trace!("invalid value id");
-                        return Err(LdapProtoError::IntermediateResponseId);
+                        Err(LdapProtoError::IntermediateResponseId)
                     }
                 }
             }
@@ -3410,6 +3410,6 @@ fn ber_integer_to_i64<V: AsRef<[u8]>>(v: V) -> Option<i64> {
     } else {
         8 - bv.len()
     };
-    raw[base..(bv.len() + base)].clone_from_slice(&bv[..]);
+    raw[base..(bv.len() + base)].clone_from_slice(bv);
     Some(i64::from_be_bytes(raw))
 }

--- a/proto/src/proto.rs
+++ b/proto/src/proto.rs
@@ -29,7 +29,7 @@ macro_rules! bytes_to_string {
         if let Ok(s) = String::from_utf8($bytes.clone()) {
             s
         } else {
-            general_purpose::URL_SAFE.encode(&$bytes)
+            format!("b64[{}]", general_purpose::URL_SAFE.encode(&$bytes))
         }
     };
 }

--- a/proto/src/proto.rs
+++ b/proto/src/proto.rs
@@ -969,7 +969,11 @@ impl TryFrom<StructureTag> for LdapMsg {
             .map(TryInto::<LdapControl>::try_into)
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(LdapMsg { msgid, op, ctrl })
+        let msg = LdapMsg { msgid, op, ctrl };
+
+        trace!(ldapmsg = ?msg);
+
+        Ok(msg)
     }
 }
 

--- a/proto/src/proto.rs
+++ b/proto/src/proto.rs
@@ -69,6 +69,8 @@ pub enum LdapControl {
         size: i64,
         cookie: String,
     },
+    ManageDsaIT,
+    Unknown { oid: String },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -1208,9 +1210,14 @@ impl TryFrom<StructureTag> for LdapControl {
 
                 Ok(LdapControl::SimplePagedResults { size, cookie })
             }
-            o => {
-                error!(%o, "Unsupported control oid");
-                Err(())
+            "2.16.840.1.113730.3.4.2" => {
+                // ManageDsaIT per https://www.rfc-editor.org/rfc/rfc3296
+                // Has no content.
+                Ok(LdapControl::ManageDsaIT)
+            }
+            oid => {
+                warn!(%o, "Unsupported control oid");
+                Ok(LdapControl::Unknown { oid: oid.to_string() })
             }
         }
     }

--- a/proto/src/serde.rs
+++ b/proto/src/serde.rs
@@ -6,7 +6,7 @@ use serde::{de, Deserialize, Deserializer};
 
 impl<'de> Deserialize<'de> for LdapFilter {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        fn de_error<E: de::Error>(e: peg::error::ParseError<peg::str::LineCol>) -> E {
+        fn de_error<E: de::Error>(e: &peg::error::ParseError<peg::str::LineCol>) -> E {
             E::custom(format_args!("LdapFilter parsing failed: {}", e))
         }
 
@@ -20,7 +20,7 @@ impl<'de> Deserialize<'de> for LdapFilter {
             }
 
             fn visit_str<E: de::Error>(self, value: &str) -> Result<LdapFilter, E> {
-                ldapfilter::parse(value).map_err(de_error)
+                ldapfilter::parse(value).map_err(|e| de_error(&e))
             }
         }
 


### PR DESCRIPTION
Fixes #28 - this is a large clean up that improves error handling, better support for controls, resolves a lot of clippy lints, and add's max-ber-size limiting to the ldapcodec. 