### PR TITLE
Fix Build Problem, missing Derive for SaslCredentials

### DIFF
--- a/proto/src/proto.rs
+++ b/proto/src/proto.rs
@@ -281,6 +281,8 @@ pub enum LdapBindCred {
 }
 
 #[derive(Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", serde(rename = "snake_case"))]
 pub struct SaslCredentials {
     pub mechanism: String,
     pub credentials: Vec<u8>,


### PR DESCRIPTION
Missing cfg_attr and Serde derive attributes. This happens because previous  two consecutive commits merged did not assume the changes from each other.