### PR TITLE
Fix: Search filter substring failure

### DIFF
--- a/proto/examples/search/main.rs
+++ b/proto/examples/search/main.rs
@@ -8,7 +8,7 @@ use ldap3_proto::{
 };
 use tokio::net::TcpStream;
 use tokio_util::codec::Framed;
-use tracing::Level;
+use tracing::{info, Level};
 
 #[tokio::main]
 pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -42,7 +42,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
             if let LdapOp::BindResponse(res) = msg.op {
                 match res.res.code {
                     LdapResultCode::Success => {
-                        println!("Bind successful");
+                        info!("Bind successful");
                         break;
                     }
                     _ => {
@@ -78,6 +78,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     loop {
         let res = framed.next().await.expect("no meg")?;
         if let LdapOp::SearchResultDone(..) = &res.op {
+            info!("search sucessfull");
             break;
         }
     }

--- a/proto/examples/search/main.rs
+++ b/proto/examples/search/main.rs
@@ -77,7 +77,6 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     loop {
         let res = framed.next().await.expect("no meg")?;
-        dbg!(&res);
         if let LdapOp::SearchResultDone(..) = &res.op {
             break;
         }

--- a/proto/examples/search/main.rs
+++ b/proto/examples/search/main.rs
@@ -1,0 +1,87 @@
+use std::{env, net::SocketAddr, str::FromStr, vec};
+
+use futures_util::{SinkExt, StreamExt};
+use ldap3_proto::{
+    parse_ldap_filter_str,
+    proto::{LdapBindCred, LdapBindRequest, LdapOp, LdapSearchRequest},
+    LdapCodec, LdapMsg, LdapResultCode,
+};
+use tokio::net::TcpStream;
+use tokio_util::codec::Framed;
+use tracing::Level;
+
+#[tokio::main]
+pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let subs = tracing_subscriber::FmtSubscriber::builder()
+        .with_max_level(Level::DEBUG)
+        .finish();
+    tracing::subscriber::set_global_default(subs).expect("setting default subscriber failed");
+
+    let ldap_password = env::var("LDAP_PASSWORD").unwrap(); // password
+    let ldap_server_addr = env::var("LDAP_SERVER_ADDR").unwrap(); // domain.com:port
+    let ldap_username_dn = env::var("LDAP_USERNAME_DN").unwrap(); // username@domain
+    let addr = SocketAddr::from_str(&ldap_server_addr)
+        .unwrap_or_else(|_| panic!("Unable to parse address, addr is {:?}", &ldap_server_addr));
+
+    let tcpstream = TcpStream::connect(addr).await?;
+
+    let mut framed = Framed::new(tcpstream, LdapCodec::default());
+
+    let msg = LdapMsg {
+        msgid: 1,
+        op: LdapOp::BindRequest(LdapBindRequest {
+            dn: ldap_username_dn,
+            cred: LdapBindCred::Simple(ldap_password),
+        }),
+        ctrl: vec![],
+    };
+
+    framed.send(msg).await?;
+    loop {
+        if let Some(Ok(msg)) = framed.next().await {
+            if let LdapOp::BindResponse(res) = msg.op {
+                match res.res.code {
+                    LdapResultCode::Success => {
+                        println!("Bind successful");
+                        break;
+                    }
+                    _ => {
+                        panic!("Bind failed: {:?}", res)
+                    }
+                }
+            }
+        } else {
+            panic!("Unable to get bind response")
+        }
+    }
+
+    let filter = parse_ldap_filter_str("(cn=*Info*)")?;
+    let search_req = LdapSearchRequest {
+        attrs: vec!["cn".to_string()],
+        base: "CN=Schema,CN=Configuration,DC=example,DC=com".to_string(),
+        filter,
+        scope: ldap3_proto::LdapSearchScope::Subtree,
+        sizelimit: 10,
+        timelimit: 100,
+        aliases: ldap3_proto::proto::LdapDerefAliases::Never,
+        typesonly: true,
+    };
+
+    let msg = LdapMsg {
+        ctrl: vec![],
+        msgid: 1,
+        op: LdapOp::SearchRequest(search_req),
+    };
+
+    framed.send(msg).await?;
+
+    loop {
+        let res = framed.next().await.expect("no meg")?;
+        dbg!(&res);
+        if let LdapOp::SearchResultDone(..) = &res.op {
+            break;
+        }
+    }
+
+    Ok(())
+}

--- a/proto/src/filter.rs
+++ b/proto/src/filter.rs
@@ -43,7 +43,7 @@ peg::parser! {
                  else if !v.contains('*') {
                     LdapFilter::Equality(a, v)
                 }else{
-                    let substring_filter :LdapSubstringFilter = v.as_str().into();
+                    let substring_filter :LdapSubstringFilter = v.into();
                     LdapFilter::Substring(a, substring_filter)
                 }
             }

--- a/proto/src/filter.rs
+++ b/proto/src/filter.rs
@@ -12,7 +12,6 @@ peg::parser! {
             not()
             / and()
             / or()
-            // / pres()
             / gte()
             / lte()
             / approx()

--- a/proto/src/filter.rs
+++ b/proto/src/filter.rs
@@ -43,7 +43,7 @@ peg::parser! {
                  else if !v.contains('*') {
                     LdapFilter::Equality(a, v)
                 }else{
-                    let substring_filter :LdapSubstringFilter = v.into();
+                    let substring_filter :LdapSubstringFilter = v.as_str().into();
                     LdapFilter::Substring(a, substring_filter)
                 }
             }

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -638,35 +638,35 @@ mod tests {
     #[test]
     pub fn test_substring_filter() {
         // Test with initial, any, and final
-        let filter: LdapSubstringFilter = "Start*Mid1*Mid2*End".to_string().as_str().into();
+        let filter: LdapSubstringFilter = "Start*Mid1*Mid2*End".into();
         assert_eq!(filter.initial, Some("Start".to_string()));
         assert_eq!(filter.any, vec!["Mid1".to_string(), "Mid2".to_string()]);
         assert_eq!(filter.final_, Some("End".to_string()));
 
-        let filter: LdapSubstringFilter = "Start*Mid1*End".to_string().as_str().into();
+        let filter: LdapSubstringFilter = "Start*Mid1*End".into();
         assert_eq!(filter.initial, Some("Start".to_string()));
         assert_eq!(filter.any, vec!["Mid1".to_string()]);
         assert_eq!(filter.final_, Some("End".to_string()));
 
         // Test with only any
-        let filter: LdapSubstringFilter = "*OnlyAny*".to_string().as_str().into();
+        let filter: LdapSubstringFilter = "*OnlyAny*".into();
         assert_eq!(filter.initial, None);
         assert_eq!(filter.any, vec!["OnlyAny".to_string()]);
         assert_eq!(filter.final_, None);
 
-        let filter: LdapSubstringFilter = "*Mid*End".to_string().as_str().into();
+        let filter: LdapSubstringFilter = "*Mid*End".into();
         assert_eq!(filter.initial, None);
         assert_eq!(filter.any, vec!["Mid".to_string()]);
         assert_eq!(filter.final_, Some("End".to_string()));
 
         // Test with no final, but has initial
-        let filter: LdapSubstringFilter = "Start*Mid*".to_string().as_str().into();
+        let filter: LdapSubstringFilter = "Start*Mid*".into();
         assert_eq!(filter.initial, Some("Start".to_string()));
         assert_eq!(filter.any, vec!["Mid".to_string()]);
         assert_eq!(filter.final_, None);
 
         // Test with one initial and one final
-        let filter: LdapSubstringFilter = "Start*End".to_string().as_str().into();
+        let filter: LdapSubstringFilter = "Start*End".into();
         assert_eq!(filter.initial, Some("Start".to_string()));
         assert_eq!(filter.any, Vec::<String>::new());
         assert_eq!(filter.final_, Some("End".to_string()));

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -109,9 +109,12 @@ impl Encoder<LdapMsg> for LdapCodec {
 
 #[cfg(test)]
 mod tests {
+    use crate::parse_ldap_filter_str;
     use crate::proto::*;
     use crate::LdapCodec;
     use bytes::BytesMut;
+    use lber::common::TagClass;
+    use lber::structures::Tag;
     use std::convert::TryInto;
     use tokio_util::codec::{Decoder, Encoder};
 
@@ -569,5 +572,124 @@ mod tests {
             // 110, 49, 8, 4, 6, 77, 111, 114, 114, 105, 115,
         ]);
         assert!(matches!(parse_result, Err(nom::Err::Incomplete(_))));
+    }
+
+    #[test]
+    fn test_parse_wild_card() {
+        let filter = parse_ldap_filter_str("(cn=Info*Tech*Test)").unwrap();
+        let tag: Tag = filter.try_into().expect("filters cannot convert into tags");
+        if let Tag::Sequence(mut sequence) = tag {
+            assert_eq!(sequence.id, 4);
+            assert_eq!(sequence.class, TagClass::Context);
+
+            let mut substring_filter_tags = match sequence.inner.pop().unwrap() {
+                Tag::Sequence(sequence) => sequence,
+                _ => panic!("substring_filter_tags sould be squence"),
+            }
+            .inner;
+            let cn = sequence.inner.pop().unwrap();
+            match cn {
+                Tag::OctetString(string) => {
+                    assert_eq!(string.id, 4);
+                    assert_eq!(string.class, TagClass::Universal);
+                    assert_eq!(string.inner, b"cn".to_vec());
+                }
+                _ => panic!("cn expected to be string"),
+            }
+
+            // Check the final component
+            let final_ = substring_filter_tags
+                .pop()
+                .expect("expecting final component");
+            if let Tag::OctetString(octet_string) = final_ {
+                assert_eq!(octet_string.id, 2);
+                assert_eq!(octet_string.class, TagClass::Context);
+                assert_eq!(octet_string.inner, b"Test".to_vec());
+            } else {
+                panic!("final component test failed")
+            }
+
+            // Check the 'any' component
+            let any = substring_filter_tags
+                .pop()
+                .expect("expecting any component");
+            if let Tag::OctetString(octet_string) = any {
+                assert_eq!(octet_string.id, 1);
+                assert_eq!(octet_string.class, TagClass::Context);
+                assert_eq!(octet_string.inner, b"Tech".to_vec());
+            } else {
+                panic!("any component test failed")
+            }
+
+            // Check the initial component
+            let initial = substring_filter_tags
+                .pop()
+                .expect("expecting initial component");
+            if let Tag::OctetString(octet_string) = initial {
+                assert_eq!(octet_string.id, 0);
+                assert_eq!(octet_string.class, TagClass::Context);
+                assert_eq!(octet_string.inner, b"Info".to_vec());
+            } else {
+                panic!("initial component test failed")
+            }
+        }
+    }
+
+    #[test]
+    pub fn test_substring_filter() {
+        // Test with initial, any, and final
+        let filter: LdapSubstringFilter = "Start*Mid1*Mid2*End".to_string().into();
+        assert_eq!(filter.initial, Some("Start".to_string()));
+        assert_eq!(filter.any, vec!["Mid1".to_string(), "Mid2".to_string()]);
+        assert_eq!(filter.final_, Some("End".to_string()));
+
+        let filter: LdapSubstringFilter = "Start*Mid1*End".to_string().into();
+        assert_eq!(filter.initial, Some("Start".to_string()));
+        assert_eq!(filter.any, vec!["Mid1".to_string()]);
+        assert_eq!(filter.final_, Some("End".to_string()));
+
+        // Test with only any
+        let filter: LdapSubstringFilter = "*OnlyAny*".to_string().into();
+        assert_eq!(filter.initial, None);
+        assert_eq!(filter.any, vec!["OnlyAny".to_string()]);
+        assert_eq!(filter.final_, None);
+
+        let filter: LdapSubstringFilter = "*Mid*End".to_string().into();
+        assert_eq!(filter.initial, None);
+        assert_eq!(filter.any, vec!["Mid".to_string()]);
+        assert_eq!(filter.final_, Some("End".to_string()));
+
+        // Test with no final, but has initial
+        let filter: LdapSubstringFilter = "Start*Mid*".to_string().into();
+        assert_eq!(filter.initial, Some("Start".to_string()));
+        assert_eq!(filter.any, vec!["Mid".to_string()]);
+        assert_eq!(filter.final_, None);
+
+        // Test with one initial and one final
+        let filter: LdapSubstringFilter = "Start*End".to_string().into();
+        assert_eq!(filter.initial, Some("Start".to_string()));
+        assert_eq!(filter.any, Vec::<String>::new());
+        assert_eq!(filter.final_, Some("End".to_string()));
+    }
+
+    #[test]
+    pub fn test_present_filter() {
+        let filter = parse_ldap_filter_str("(cn=*)").unwrap();
+        if let LdapFilter::Present(p) = filter {
+            assert_eq!(p, "cn")
+        } else {
+            panic!("present search filter broken");
+        }
+    }
+
+    #[test]
+    pub fn test_equality_filter() {
+        let filter = parse_ldap_filter_str("(cn=test)").unwrap();
+        if let LdapFilter::Equality(name, value) = filter {
+            assert_eq!(name, "cn");
+            assert_eq!(value, "test")
+        } else {
+            panic!("present search filter broken");
+        }
     }
 }

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -638,35 +638,35 @@ mod tests {
     #[test]
     pub fn test_substring_filter() {
         // Test with initial, any, and final
-        let filter: LdapSubstringFilter = "Start*Mid1*Mid2*End".to_string().into();
+        let filter: LdapSubstringFilter = "Start*Mid1*Mid2*End".to_string().as_str().into();
         assert_eq!(filter.initial, Some("Start".to_string()));
         assert_eq!(filter.any, vec!["Mid1".to_string(), "Mid2".to_string()]);
         assert_eq!(filter.final_, Some("End".to_string()));
 
-        let filter: LdapSubstringFilter = "Start*Mid1*End".to_string().into();
+        let filter: LdapSubstringFilter = "Start*Mid1*End".to_string().as_str().into();
         assert_eq!(filter.initial, Some("Start".to_string()));
         assert_eq!(filter.any, vec!["Mid1".to_string()]);
         assert_eq!(filter.final_, Some("End".to_string()));
 
         // Test with only any
-        let filter: LdapSubstringFilter = "*OnlyAny*".to_string().into();
+        let filter: LdapSubstringFilter = "*OnlyAny*".to_string().as_str().into();
         assert_eq!(filter.initial, None);
         assert_eq!(filter.any, vec!["OnlyAny".to_string()]);
         assert_eq!(filter.final_, None);
 
-        let filter: LdapSubstringFilter = "*Mid*End".to_string().into();
+        let filter: LdapSubstringFilter = "*Mid*End".to_string().as_str().into();
         assert_eq!(filter.initial, None);
         assert_eq!(filter.any, vec!["Mid".to_string()]);
         assert_eq!(filter.final_, Some("End".to_string()));
 
         // Test with no final, but has initial
-        let filter: LdapSubstringFilter = "Start*Mid*".to_string().into();
+        let filter: LdapSubstringFilter = "Start*Mid*".to_string().as_str().into();
         assert_eq!(filter.initial, Some("Start".to_string()));
         assert_eq!(filter.any, vec!["Mid".to_string()]);
         assert_eq!(filter.final_, None);
 
         // Test with one initial and one final
-        let filter: LdapSubstringFilter = "Start*End".to_string().into();
+        let filter: LdapSubstringFilter = "Start*End".to_string().as_str().into();
         assert_eq!(filter.initial, Some("Start".to_string()));
         assert_eq!(filter.any, Vec::<String>::new());
         assert_eq!(filter.final_, Some("End".to_string()));

--- a/proto/src/proto.rs
+++ b/proto/src/proto.rs
@@ -383,22 +383,28 @@ impl From<&str> for LdapSubstringFilter {
             final_: None,
         };
 
-        let value_count = value.split('*').count();
-        let last_char = value.chars().last();
-        let first_char = value.chars().next();
-        value.split('*').enumerate().for_each(|(idx, v)| {
-            if idx == 0 && first_char != Some('*') {
-                filter.initial = Some(v.to_string())
-            } else if idx == value_count - 1 && last_char != Some('*') {
-                filter.final_ = Some(v.to_string())
-            } else if v.is_empty() {
-                // pass
-            } else {
-                filter.any.push(v.to_string())
+        let mut split_iter = value.split('*');
+        if let Some(start) = split_iter.next() {
+            if !start.is_empty() {
+                filter.initial = Some(start.to_string());
             }
-        });
+        }
+
+        if let Some(end) = split_iter.next_back() {
+            if !end.is_empty() {
+                filter.final_ = Some(end.to_string());
+            }
+        }
+
+        split_iter.for_each(|v| filter.any.push(v.to_string()));
 
         filter
+    }
+}
+
+impl From<String> for LdapSubstringFilter {
+    fn from(value: String) -> Self {
+        Self::from(value.as_str())
     }
 }
 

--- a/proto/src/proto.rs
+++ b/proto/src/proto.rs
@@ -386,21 +386,17 @@ impl From<&str> for LdapSubstringFilter {
         let value_count = value.split('*').count();
         let last_char = value.chars().last();
         let first_char = value.chars().next();
-        value
-            .split('*')
-            .enumerate()
-            .into_iter()
-            .for_each(|(idx, v)| {
-                if idx == 0 && first_char != Some('*') {
-                    filter.initial = Some(v.to_string())
-                } else if idx == value_count - 1 && last_char != Some('*') {
-                    filter.final_ = Some(v.to_string())
-                } else if v.is_empty() {
-                    // pass
-                } else {
-                    filter.any.push(v.to_string())
-                }
-            });
+        value.split('*').enumerate().for_each(|(idx, v)| {
+            if idx == 0 && first_char != Some('*') {
+                filter.initial = Some(v.to_string())
+            } else if idx == value_count - 1 && last_char != Some('*') {
+                filter.final_ = Some(v.to_string())
+            } else if v.is_empty() {
+                // pass
+            } else {
+                filter.any.push(v.to_string())
+            }
+        });
 
         filter
     }

--- a/proto/src/proto.rs
+++ b/proto/src/proto.rs
@@ -395,7 +395,7 @@ impl From<&str> for LdapSubstringFilter {
                     filter.initial = Some(v.to_string())
                 } else if idx == value_count - 1 && last_char != Some('*') {
                     filter.final_ = Some(v.to_string())
-                } else if v == "" {
+                } else if v.is_empty() {
                     // pass
                 } else {
                     filter.any.push(v.to_string())


### PR DESCRIPTION
fix search filter substring failure https://github.com/kanidm/ldap3/issues/39, for both parsing and encoding.

Added test for parsing and encoding for changed code
Added example to test against real AD server

Wireshark and Active Directory recognize this change
![image](https://github.com/kanidm/ldap3/assets/139169536/2444e8db-230b-4e4e-85ef-56446a18cd3b)


BTW, there is one test that is not related to my change fails on master.
