### PR TITLE
Refactor parameter types: change some String parameters to traits and…

### DIFF
--- a/cli/src/ldap_opt.rs
+++ b/cli/src/ldap_opt.rs
@@ -12,6 +12,8 @@ impl Default for SyncRequestMode {
 }
 */
 
+use url::Url;
+
 #[derive(Debug, clap::Subcommand)]
 enum LdapAction {
     /// Search a directory server
@@ -58,7 +60,7 @@ struct LdapOpt {
     verbose: bool,
 
     #[clap(short = 'H', long = "url")]
-    url: String,
+    url: Url,
 
     #[clap(short = 'j', long = "json")]
     json: bool,

--- a/cli/src/ldap_opt.rs
+++ b/cli/src/ldap_opt.rs
@@ -58,7 +58,7 @@ struct LdapOpt {
     verbose: bool,
 
     #[clap(short = 'H', long = "url")]
-    url: url::Url,
+    url: String,
 
     #[clap(short = 'j', long = "json")]
     json: bool,

--- a/client/src/addirsync.rs
+++ b/client/src/addirsync.rs
@@ -18,9 +18,9 @@ pub struct LdapSyncRepl {
 
 impl LdapClient {
     #[tracing::instrument(level = "debug", skip_all)]
-    pub async fn ad_dirsync(
+    pub async fn ad_dirsync<S: Into<String>>(
         &mut self,
-        basedn: String,
+        basedn: S,
         cookie: Option<Vec<u8>>,
     ) -> crate::LdapResult<LdapSyncRepl> {
         let msgid = self.get_next_msgid();
@@ -28,7 +28,7 @@ impl LdapClient {
         let msg = LdapMsg {
             msgid,
             op: LdapOp::SearchRequest(LdapSearchRequest {
-                base: basedn,
+                base: basedn.into(),
                 scope: LdapSearchScope::Subtree,
                 aliases: LdapDerefAliases::Never,
                 sizelimit: 0,

--- a/client/src/search.rs
+++ b/client/src/search.rs
@@ -8,9 +8,9 @@ pub struct LdapSearchResult {
 
 impl LdapClient {
     #[tracing::instrument(level = "debug", skip_all)]
-    pub async fn search(
+    pub async fn search<S: Into<String>>(
         &mut self,
-        basedn: String,
+        basedn: S,
         filter: LdapFilter,
     ) -> crate::LdapResult<LdapSearchResult> {
         let msgid = self.get_next_msgid();
@@ -18,7 +18,7 @@ impl LdapClient {
         let msg = LdapMsg {
             msgid,
             op: LdapOp::SearchRequest(LdapSearchRequest {
-                base: basedn,
+                base: basedn.into(),
                 scope: LdapSearchScope::Subtree,
                 aliases: LdapDerefAliases::Never,
                 sizelimit: 0,

--- a/client/src/syncrepl.rs
+++ b/client/src/syncrepl.rs
@@ -46,9 +46,9 @@ pub enum LdapSyncRepl {
 
 impl LdapClient {
     #[tracing::instrument(level = "debug", skip_all)]
-    pub async fn syncrepl(
+    pub async fn syncrepl<S: Into<String>>(
         &mut self,
-        basedn: String,
+        basedn: S,
         filter: LdapFilter,
         cookie: Option<Vec<u8>>,
         mode: SyncRequestMode,
@@ -58,7 +58,7 @@ impl LdapClient {
         let msg = LdapMsg {
             msgid,
             op: LdapOp::SearchRequest(LdapSearchRequest {
-                base: basedn,
+                base: basedn.into(),
                 scope: LdapSearchScope::Subtree,
                 aliases: LdapDerefAliases::Never,
                 sizelimit: 0,


### PR DESCRIPTION
When constructing the `LdapClient` using `LdapClientBuilder`, there is no need for the user to manually construct the URL as a `Url` type before passing it in. Instead, it should be automatically converted to a `Url` type by the library during the actual build process, which can enhance the user experience. The same reasoning applies to the `basedn` in other client query operations.